### PR TITLE
Add Auction Details & Utilities to Auction Page

### DIFF
--- a/container/CrabV2/Auction/Auction.tsx
+++ b/container/CrabV2/Auction/Auction.tsx
@@ -16,6 +16,7 @@ import Approvals from './Approvals'
 import { V2_AUCTION_TIME } from '../../../constants/numbers'
 import Countdown, { CountdownRendererFn } from 'react-countdown'
 import { AuctionStatus } from '../../../types'
+import AuctionInfo from './AuctionInfo'
 
 const renderer: CountdownRendererFn = ({ minutes, seconds }) => {
   // Render a countdown
@@ -70,6 +71,9 @@ const Auction: React.FC = () => {
           </Typography>
           <Box display="flex" mt={1}>
             <AuctionBody />
+          </Box>
+          <Box display="flex" mt={1}>
+            <AuctionInfo />
           </Box>
         </>
       ) : null}

--- a/container/CrabV2/Auction/AuctionInfo.tsx
+++ b/container/CrabV2/Auction/AuctionInfo.tsx
@@ -1,0 +1,41 @@
+import { Grid, Typography } from '@mui/material'
+import { Box } from '@mui/system'
+import React from 'react'
+
+const AuctionBody: React.FC = () => {
+  return (
+    <Grid container spacing={5}>
+      <Grid item xs={12} md={12} lg={8}>
+        <AuctionDetails />
+      </Grid>
+      <Grid item xs={12} md={12} lg={4}>
+        <div />
+      </Grid>
+    </Grid>
+  )
+}
+
+const AuctionDetails: React.FC = () => {
+  return (
+    <Box
+      boxShadow={1}
+      py={2}
+      px={4}
+      borderRadius={2}
+      bgcolor="background.overlayDark"
+      display="flex"
+      flexDirection="column"
+    >
+      <Typography variant="h6" mt={1}>
+        Auction Details
+      </Typography>
+      <ul>
+        <li>The auction will run approximately MWF at 9:30AM PT, but could be discretionarily more or less frequent</li>
+        <li>Bids are selected by best price that will clear size</li>
+        <li>The auction may be re-run infrequently if needed eg. ETH price moves, not enough bids</li>
+      </ul>
+    </Box>
+  )
+}
+
+export default AuctionBody

--- a/container/CrabV2/Auction/AuctionInfo.tsx
+++ b/container/CrabV2/Auction/AuctionInfo.tsx
@@ -4,12 +4,12 @@ import React from 'react'
 
 const AuctionBody: React.FC = () => {
   return (
-    <Grid container spacing={5}>
-      <Grid item xs={12} md={12} lg={8}>
+    <Grid container spacing={5} mt={1} mb={5}>
+      <Grid item xs={12} md={12} lg={9}>
         <AuctionDetails />
       </Grid>
-      <Grid item xs={12} md={12} lg={4}>
-        <div />
+      <Grid item xs={12} md={12} lg={3}>
+        <AuctionUtils />
       </Grid>
     </Grid>
   )
@@ -30,9 +30,31 @@ const AuctionDetails: React.FC = () => {
         Auction Details
       </Typography>
       <ul>
-        <li>The auction will run approximately MWF at 9:30AM PT, but could be discretionarily more or less frequent</li>
-        <li>Bids are selected by best price that will clear size</li>
-        <li>The auction may be re-run infrequently if needed eg. ETH price moves, not enough bids</li>
+        <li><Typography variant="body3">The auction will run approximately MWF at 9:30AM PT, but could be discretionarily more or less frequent</Typography></li>
+        <li><Typography variant="body3">Bids are selected by best price that will clear size</Typography></li>
+        <li><Typography variant="body3">The auction may be re-run infrequently if needed eg. ETH price moves, not enough bids</Typography></li>
+      </ul>
+    </Box>
+  )
+}
+
+const AuctionUtils: React.FC = () => {
+  return (
+    <Box
+      boxShadow={1}
+      py={3}
+      px={4}
+      borderRadius={2}
+      bgcolor="background.overlayDark"
+      display="flex"
+      flexDirection="column"
+    >
+      <Typography variant="h6" mt={1} mb={1}>
+        Utilities
+      </Typography>
+      <ul>
+        <li><a href="https://squeeth.opyn.co/"><Typography color="primary">Mint / burn oSQTH</Typography></a></li>
+        <li><a href="https://app.uniswap.org/#/swap"><Typography color="primary">Wrap / unwrap WETH</Typography></a></li>
       </ul>
     </Box>
   )


### PR DESCRIPTION
Auction Details specified in [design](https://www.figma.com/file/3huyp0RyUiyS7D02vWSVnd/Crabby-testin?node-id=24%3A314).

Utilities link to [squeeth.com](squeeth.com) and [uniswap](https://app.uniswap.org/#/swap).

<img width="1301" alt="Screen Shot 2022-07-20 at 7 05 48 PM" src="https://user-images.githubusercontent.com/29926727/180114081-2e9fad98-6c4c-4cf6-a57f-03a472b05b6a.png">