### PR TITLE
Add bid time to view for both admin and user view

### DIFF
--- a/container/CrabV2/Auction/Admin/AdminBidView.tsx
+++ b/container/CrabV2/Auction/Admin/AdminBidView.tsx
@@ -39,6 +39,9 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import useControllerStore from '../../../../store/controllerStore'
 import usePriceStore from '../../../../store/priceStore'
 import shallow from 'zustand/shallow'
+import { Fragment } from 'react'
+import { HtmlTooltip } from '../../../../components/utilities/HtmlTooltip'
+import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined'
 
 const AdminBidView: React.FC = () => {
   const [filteredBids, setFilteredBids] = React.useState<Array<Bid & { status?: BidStatus }>>()
@@ -341,6 +344,7 @@ const BidRow: React.FC<BidRowProp> = ({ bid, rank, checkEnabled, onCheck }) => {
 
   const ethPrice = convertBigNumber(ethPriceBN, 18)
   const nf = convertBigNumber(nfBN, 18)
+  const bidTime = new Date(bid.order.nonce).toString()
 
   return (
     <>
@@ -381,6 +385,15 @@ const BidRow: React.FC<BidRowProp> = ({ bid, rank, checkEnabled, onCheck }) => {
         <Typography variant="body3" color="textSecondary">
           {getBidStatus(bid.status)}
         </Typography>
+        <HtmlTooltip
+            title={
+              <Fragment>
+                Bid entered/Last updated time: {bidTime}
+              </Fragment>
+            }
+          >
+            <TimerOutlinedIcon fontSize="inherit" color="inherit" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
+          </HtmlTooltip>
       </TableCell>
     </>
   )

--- a/container/CrabV2/Auction/Admin/AdminBidView.tsx
+++ b/container/CrabV2/Auction/Admin/AdminBidView.tsx
@@ -344,7 +344,8 @@ const BidRow: React.FC<BidRowProp> = ({ bid, rank, checkEnabled, onCheck }) => {
 
   const ethPrice = convertBigNumber(ethPriceBN, 18)
   const nf = convertBigNumber(nfBN, 18)
-  const bidTime = new Date(bid.order.nonce).toString()
+  // For older auction it uses nonce, for auctions that will be created hereafter will use updated time
+  const bidTime = new Date(bid.updatedTime || bid.order.nonce).toString()
 
   return (
     <>
@@ -385,15 +386,9 @@ const BidRow: React.FC<BidRowProp> = ({ bid, rank, checkEnabled, onCheck }) => {
         <Typography variant="body3" color="textSecondary">
           {getBidStatus(bid.status)}
         </Typography>
-        <HtmlTooltip
-            title={
-              <Fragment>
-                Bid entered/Last updated time: {bidTime}
-              </Fragment>
-            }
-          >
-            <TimerOutlinedIcon fontSize="inherit" color="inherit" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
-          </HtmlTooltip>
+        <HtmlTooltip title={<Fragment>Bid entered/Last updated time: {bidTime}</Fragment>}>
+          <TimerOutlinedIcon fontSize="inherit" color="inherit" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
+        </HtmlTooltip>
       </TableCell>
     </>
   )

--- a/container/CrabV2/Auction/Bids.tsx
+++ b/container/CrabV2/Auction/Bids.tsx
@@ -115,7 +115,8 @@ const BidRow: React.FC<{ bid: BidWithAmount; rank: number }> = ({ bid, rank }) =
 
   const qty = BigNumber.from(bid.order.quantity)
   const price = BigNumber.from(bid.order.price)
-  const bidTime = new Date(bid.order.nonce).toString()
+  // For older auction it uses nonce, for auctions that will be created hereafter will use updated time
+  const bidTime = new Date(bid.updatedTime || bid.order.nonce).toString()
 
   const { ethPriceBN } = usePriceStore(s => ({ ethPriceBN: s.ethPrice }), shallow)
 
@@ -151,34 +152,22 @@ const BidRow: React.FC<{ bid: BidWithAmount; rank: number }> = ({ bid, rank }) =
               ? `Partial: ${formatBigNumber(bid.filledAmount, 18, 5)}`
               : getBidStatus(bid.status)}
           </Typography>
-          <HtmlTooltip
-            title={
-              <Fragment>
-                 Bid entered/Last updated time: {bidTime}
-              </Fragment>
-            }
-          >
+          <HtmlTooltip title={<Fragment>Bid entered/Last updated time: {bidTime}</Fragment>}>
             <TimerOutlinedIcon fontSize="inherit" color="inherit" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
           </HtmlTooltip>
         </TableCell>
-       ) : (
+      ) : (
         <TableCell align="right">
           {address === bid.bidder ? (
             <Button variant="text" onClick={() => setBidToEdit(`${bid.bidder}-${bid.order.nonce}`)}>
               Edit
             </Button>
           ) : null}
-          <HtmlTooltip
-            title={
-              <Fragment>
-                Bid entered/Last updated time: {bidTime}
-              </Fragment>
-            }
-          >
+          <HtmlTooltip title={<Fragment>Bid entered/Last updated time: {bidTime}</Fragment>}>
             <TimerOutlinedIcon fontSize="inherit" color="inherit" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
           </HtmlTooltip>
         </TableCell>
-       )} 
+      )}
     </>
   )
 }

--- a/container/CrabV2/Auction/Bids.tsx
+++ b/container/CrabV2/Auction/Bids.tsx
@@ -15,6 +15,9 @@ import { Auction, AuctionStatus, Bid, BidStatus, BidWithStatus } from '../../../
 import usePriceStore from '../../../store/priceStore'
 import shallow from 'zustand/shallow'
 import useControllerStore from '../../../store/controllerStore'
+import { HtmlTooltip } from '../../../components/utilities/HtmlTooltip'
+import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined'
+import { Fragment } from 'react'
 
 const getStatus = (auction: Auction, isHistoricalView: boolean, bid: Bid, clearingPrice: string, amount: string) => {
   if (isHistoricalView) {
@@ -112,6 +115,7 @@ const BidRow: React.FC<{ bid: BidWithAmount; rank: number }> = ({ bid, rank }) =
 
   const qty = BigNumber.from(bid.order.quantity)
   const price = BigNumber.from(bid.order.price)
+  const bidTime = new Date(bid.order.nonce).toString()
 
   const { ethPriceBN } = usePriceStore(s => ({ ethPriceBN: s.ethPrice }), shallow)
 
@@ -147,16 +151,34 @@ const BidRow: React.FC<{ bid: BidWithAmount; rank: number }> = ({ bid, rank }) =
               ? `Partial: ${formatBigNumber(bid.filledAmount, 18, 5)}`
               : getBidStatus(bid.status)}
           </Typography>
+          <HtmlTooltip
+            title={
+              <Fragment>
+                 Bid entered/Last updated time: {bidTime}
+              </Fragment>
+            }
+          >
+            <TimerOutlinedIcon fontSize="inherit" color="inherit" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
+          </HtmlTooltip>
         </TableCell>
-      ) : (
+       ) : (
         <TableCell align="right">
           {address === bid.bidder ? (
             <Button variant="text" onClick={() => setBidToEdit(`${bid.bidder}-${bid.order.nonce}`)}>
               Edit
             </Button>
           ) : null}
+          <HtmlTooltip
+            title={
+              <Fragment>
+                Bid entered/Last updated time: {bidTime}
+              </Fragment>
+            }
+          >
+            <TimerOutlinedIcon fontSize="inherit" color="inherit" sx={{ verticalAlign: 'middle', ml: 0.5 }} />
+          </HtmlTooltip>
         </TableCell>
-      )}
+       )} 
     </>
   )
 }

--- a/pages/api/auction/createOrEditBid.ts
+++ b/pages/api/auction/createOrEditBid.ts
@@ -40,6 +40,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     order,
     bidder: order.trader,
     signature,
+    updatedTime: Date.now(),
   }
   auction.bids[`${bid.bidder}-${order.nonce}`] = bid
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -30,6 +30,7 @@ export type Bid = {
   order: Order
   signature: string
   bidder: string
+  updatedTime?: number
   status?: BidStatus
 }
 
@@ -49,7 +50,7 @@ export type Auction = {
   minSize: number
   ethPrice?: string
   oSqthPrice?: string
-  osqthRefVol?: number,
+  osqthRefVol?: number
   normFactor?: string
   executedTime?: number
 }

--- a/utils/auction.ts
+++ b/utils/auction.ts
@@ -47,7 +47,7 @@ export const sortBids = (auction: Auction) => {
 
 export const sortBidsForBidArray = (bids: Array<Bid>, isSelling: boolean) => {
   const sortedBids = bids.sort((a, b) => {
-    if (b.order.price === a.order.price) return Number(a.order.nonce) - Number(b.order.nonce)
+    if (b.order.price === a.order.price) return Number(a.updatedTime) - Number(b.updatedTime)
     if (isSelling) return Number(b.order.price) - Number(a.order.price)
 
     return Number(a.order.price) - Number(b.order.price)


### PR DESCRIPTION
**Details**
- Shows time bids were entered so everyone sees time related bid preference while filling orders


**Why this PR**
- Issue occurred last auuction (Nov 25), when two bids of the same limit price came in nearly the same time, we thought the frontend did not sort according to time, however turns out it did and the user whose bid came in 3 seconds earlier was fully filled while the one whose bid came in after got a partial fill
