### PR TITLE
[Fix]: Changed calculations for weth/usdc trade to match contract

### DIFF
--- a/tests/unit/calmBull.test.ts
+++ b/tests/unit/calmBull.test.ts
@@ -284,14 +284,13 @@ describe('CalmBull: Full Rebalance', () => {
     expect(wethTargetInEuler.toString()).toBe('196666667000000000000')
   })
 
-  //1
+  //4
   test('testFullRebalanceDepositCrabDecreaseEthBorrowUsdc', async () => {
-    const ethUsdPrice = BIG_ONE.mul(800)
-    const squeethEthPrice = BIG_ONE.mul(BigNumber.from(8)).div(480)
-    const crabUsdPrice = BIG_ONE.mul(480);
+    const ethUsdPrice = BIG_ONE.mul(1200)
+    const squeethEthPrice = BIG_ONE.mul(BigNumber.from(10)).div(100)
+    const crabUsdPrice = BIG_ONE.mul(500);
 
     const loanCollat = BIG_ONE.mul(200)
-    // const ethInCrab = BIG_ONE.mul(1200)
 
     mockQuoterFunctions(ethUsdPrice)
 
@@ -310,23 +309,23 @@ describe('CalmBull: Full Rebalance', () => {
       quoter,
       slippageTolerance: DEFAULT_SLIPPAGE
     })
+    // console.log('isDepositingIntoCrab', isDepositingIntoCrab.toString())
+    // console.log('isIncreaseWeth', isIncreaseWeth.toString())
+    // console.log('isBorrowUsdc', isBorrowUsdc.toString())
 
+    expect(isDepositingIntoCrab).toBe(true)
     expect(isIncreaseWeth).toBe(false)
     expect(isBorrowUsdc).toBe(true)
-    expect(isDepositingIntoCrab).toBe(false)
-  //   console.log('isIncreaseWeth.toString()', isIncreaseWeth.toString())
-  //   console.log('isBorrowUsdc.toString()', isBorrowUsdc.toString(),)
-  //   console.log('isDepositingIntoCrab.toString()', isDepositingIntoCrab.toString())
+
    })
 
-   //2
-   test('testFullRebalanceWithdrawCrabIncreaseEthBorrowUsdc', async () => {
+   //6
+   test('testFullFullRebalanceWithdrawCrabIncreaseEthRepayUsdc', async () => {
     const ethUsdPrice = BIG_ONE.mul(800)
     const squeethEthPrice = BIG_ONE.mul(BigNumber.from(8)).div(480)
     const crabUsdPrice = BIG_ONE.mul(520);
 
     const loanCollat = BIG_ONE.mul(200)
-    // const ethInCrab = BIG_ONE.mul(1200)
 
     mockQuoterFunctions(ethUsdPrice)
 
@@ -346,59 +345,19 @@ describe('CalmBull: Full Rebalance', () => {
       slippageTolerance: DEFAULT_SLIPPAGE
     })
 
-    expect(isIncreaseWeth).toBe(true)
-    expect(isBorrowUsdc).toBe(true)
     expect(isDepositingIntoCrab).toBe(false)
-  //   console.log('isIncreaseWeth.toString()', isIncreaseWeth.toString())
-  //   console.log('isBorrowUsdc.toString()', isBorrowUsdc.toString(),)
-  //   console.log('isDepositingIntoCrab.toString()', isDepositingIntoCrab.toString())
+    expect(isIncreaseWeth).toBe(true)
+    expect(isBorrowUsdc).toBe(false)
    })
 
 
   //3
-  test('testFullRebalanceWithdrawCrabDecreaseEthBorrowUsdc', async () => {
-        const ethUsdPrice = BIG_ONE.mul(800)
-        const squeethEthPrice = BIG_ONE.mul(BigNumber.from(12)).div(480)
-        const crabUsdPrice = BIG_ONE.mul(480);
-    
-        const loanCollat = BIG_ONE.mul(200)
-        // const ethInCrab = BIG_ONE.mul(1200)
-    
-        mockQuoterFunctions(ethUsdPrice)
-    
-        const { isIncreaseWeth, isBorrowUsdc, isDepositingIntoCrab } = await getAuctionOutcomes({
-          crabUsdPrice,
-          squeethEthPrice,
-          loanCollat ,
-          loanDebt,
-          crabBalance,
-          squeethInCrab,
-          ethInCrab,
-          crabTotalSupply,
-          ethUsdPrice,
-          targetCr,
-          feeRate,
-          quoter,
-          slippageTolerance: DEFAULT_SLIPPAGE
-        })
-    
-        expect(isIncreaseWeth).toBe(false)
-        expect(isBorrowUsdc).toBe(true)
-        expect(isDepositingIntoCrab).toBe(false)
-      //   console.log('isIncreaseWeth.toString()', isIncreaseWeth.toString())
-      //   console.log('isBorrowUsdc.toString()', isBorrowUsdc.toString(),)
-      //   console.log('isDepositingIntoCrab.toString()', isDepositingIntoCrab.toString())
-       })
-
-
-  //4
-  test('testFullRebalanceDepositCrabDecreaseEthRepayUsdc', async () => {
-    const ethUsdPrice = BIG_ONE.mul(1200)
-    const squeethEthPrice = BIG_ONE.mul(BigNumber.from(8)).div(480)
+  test('testFullRebalanceWithdrawCrabDecreaseEthRepayUsdc', async () => {
+    const ethUsdPrice = BIG_ONE.mul(800)
+    const squeethEthPrice = BIG_ONE.mul(BigNumber.from(8)).div(100)
     const crabUsdPrice = BIG_ONE.mul(480);
 
     const loanCollat = BIG_ONE.mul(200)
-    // const ethInCrab = BIG_ONE.mul(1200)
 
     mockQuoterFunctions(ethUsdPrice)
 
@@ -418,56 +377,56 @@ describe('CalmBull: Full Rebalance', () => {
       slippageTolerance: DEFAULT_SLIPPAGE
     })
 
+    console.log('isDepositingIntoCrab', isDepositingIntoCrab.toString())
+    console.log('isIncreaseWeth', isIncreaseWeth.toString())
+    console.log('isBorrowUsdc', isBorrowUsdc.toString())
+
+    expect(isDepositingIntoCrab).toBe(false)
     expect(isIncreaseWeth).toBe(false)
     expect(isBorrowUsdc).toBe(false)
-    expect(isDepositingIntoCrab).toBe(true)
-  //   console.log('isIncreaseWeth.toString()', isIncreaseWeth.toString())
-  //   console.log('isBorrowUsdc.toString()', isBorrowUsdc.toString(),)
-  //   console.log('isDepositingIntoCrab.toString()', isDepositingIntoCrab.toString())
-   })
 
-   test('testFullRebalanceDepositCrabIncreaseEthRepayUsdc', async () => {
-    const ethUsdPrice = BIG_ONE.mul(1200)
-    const squeethEthPrice = BIG_ONE.mul(BigNumber.from(8)).div(480)
-    const crabUsdPrice = BIG_ONE.mul(520);
-
-    const loanCollat = BIG_ONE.mul(200)
-    // const ethInCrab = BIG_ONE.mul(1200)
-
-    mockQuoterFunctions(ethUsdPrice)
-
-    const { isIncreaseWeth, isBorrowUsdc, isDepositingIntoCrab } = await getAuctionOutcomes({
-      crabUsdPrice,
-      squeethEthPrice,
-      loanCollat ,
-      loanDebt,
-      crabBalance,
-      squeethInCrab,
-      ethInCrab,
-      crabTotalSupply,
-      ethUsdPrice,
-      targetCr,
-      feeRate,
-      quoter,
-      slippageTolerance: DEFAULT_SLIPPAGE
-    })
-
-    expect(isIncreaseWeth).toBe(true)
-    expect(isBorrowUsdc).toBe(false)
-    expect(isDepositingIntoCrab).toBe(true)
-  //   console.log('isIncreaseWeth.toString()', isIncreaseWeth.toString())
-  //   console.log('isBorrowUsdc.toString()', isBorrowUsdc.toString(),)
-  //   console.log('isDepositingIntoCrab.toString()', isDepositingIntoCrab.toString())
    })
 
    //5
-   test('testFullRebalanceDepositCrabDecreaseEthBorrowUsdc', async () => {
+   test('testFullRebalanceDepositCrabIncreaseEthBorrowUsdc', async () => {
+    const ethUsdPrice = BIG_ONE.mul(1200)
+    const squeethEthPrice = BIG_ONE.mul(BigNumber.from(8)).div(480)
+    const crabUsdPrice = BIG_ONE.mul(520);
+
+    const loanCollat = BIG_ONE.mul(200)
+    // const ethInCrab = BIG_ONE.mul(1200)
+
+    mockQuoterFunctions(ethUsdPrice)
+
+    const { isIncreaseWeth, isBorrowUsdc, isDepositingIntoCrab } = await getAuctionOutcomes({
+      crabUsdPrice,
+      squeethEthPrice,
+      loanCollat ,
+      loanDebt,
+      crabBalance,
+      squeethInCrab,
+      ethInCrab,
+      crabTotalSupply,
+      ethUsdPrice,
+      targetCr,
+      feeRate,
+      quoter,
+      slippageTolerance: DEFAULT_SLIPPAGE
+    })
+
+    expect(isDepositingIntoCrab).toBe(true)
+    expect(isIncreaseWeth).toBe(true)
+    expect(isBorrowUsdc).toBe(true)
+
+   })
+
+   //1
+   test('testFullRebalanceDepositCrabDecreaseEthRepayUsdc', async () => {
     const ethUsdPrice = BIG_ONE.mul(800)
     const squeethEthPrice = BIG_ONE.mul(BigNumber.from(8)).div(480)
     const crabUsdPrice = BIG_ONE.mul(480);
 
     const loanCollat = BIG_ONE.mul(250)
-    // const ethInCrab = BIG_ONE.mul(1200)
 
     mockQuoterFunctions(ethUsdPrice)
 
@@ -487,22 +446,18 @@ describe('CalmBull: Full Rebalance', () => {
       slippageTolerance: DEFAULT_SLIPPAGE
     })
 
-    expect(isIncreaseWeth).toBe(false)
-    expect(isBorrowUsdc).toBe(true)
     expect(isDepositingIntoCrab).toBe(true)
-  //   console.log('isIncreaseWeth.toString()', isIncreaseWeth.toString())
-  //   console.log('isBorrowUsdc.toString()', isBorrowUsdc.toString(),)
-  //   console.log('isDepositingIntoCrab.toString()', isDepositingIntoCrab.toString())
+    expect(isIncreaseWeth).toBe(false)
+    expect(isBorrowUsdc).toBe(false)
    })
 
-   //6
-   test('testFullRebalanceWithdrawCrabIncreaseEthRepayUsdc', async () => {
+   //2
+   test('testFullRebalanceWithdrawCrabIncreaseEthBorrrowUsdc', async () => {
     const ethUsdPrice = BIG_ONE.mul(800)
     const squeethEthPrice = BIG_ONE.mul(BigNumber.from(8)).div(480)
     const crabUsdPrice = BIG_ONE.mul(520);
 
     const loanCollat = BIG_ONE.mul(250)
-    // const ethInCrab = BIG_ONE.mul(1200)
 
     mockQuoterFunctions(ethUsdPrice)
 
@@ -522,12 +477,9 @@ describe('CalmBull: Full Rebalance', () => {
       slippageTolerance: DEFAULT_SLIPPAGE
     })
 
-    expect(isIncreaseWeth).toBe(true)
-    expect(isBorrowUsdc).toBe(false)
     expect(isDepositingIntoCrab).toBe(false)
-  //   console.log('isIncreaseWeth.toString()', isIncreaseWeth.toString())
-  //   console.log('isBorrowUsdc.toString()', isBorrowUsdc.toString(),)
-  //   console.log('isDepositingIntoCrab.toString()', isDepositingIntoCrab.toString())
+    expect(isIncreaseWeth).toBe(true)
+    expect(isBorrowUsdc).toBe(true)
    })
 
 })

--- a/utils/calmBull.ts
+++ b/utils/calmBull.ts
@@ -204,19 +204,19 @@ export async function getFullRebalanceDetails(params: getFullRebalanceType) {
     if (wethTargetInEuler.gt(loanCollat)){
       // Need more weth
       const wethToGet = wethTargetInEuler.sub(loanCollat).add(ethNeededForCrab)
-      const usdcAmount = await getUsdcAmountForWeth(wethToGet, false, quoter, slippageTolerance)
-      const wethToTrade = wethToGet
+      usdcAmount = await getUsdcAmountForWeth(wethToGet, false, quoter, slippageTolerance)
+      wethToTrade = wethToGet
     } else {
       const wethFromEuler = loanCollat.sub(wethTargetInEuler);
 
       if(ethNeededForCrab.gte(wethFromEuler)) {
         const wethToGet = ethNeededForCrab.sub(wethFromEuler)
-        const usdcAmount = await getUsdcAmountForWeth(wethToGet, false, quoter, slippageTolerance)
-        const wethToTrade = wethToGet
+        usdcAmount = await getUsdcAmountForWeth(wethToGet, false, quoter, slippageTolerance)
+        wethToTrade = wethToGet
       } else {
         const wethToSell = wethFromEuler.sub(ethNeededForCrab)
-        const usdcAmount = await getUsdcAmountForWeth(wethToSell, true, quoter, slippageTolerance)
-        const wethToTrade = wethToSell
+        usdcAmount = await getUsdcAmountForWeth(wethToSell, true, quoter, slippageTolerance)
+        wethToTrade = wethToSell
       }
     }
   } else {
@@ -226,17 +226,18 @@ export async function getFullRebalanceDetails(params: getFullRebalanceType) {
     const netWethReceived = wethFromCrab.sub(wethToAuction)
     if (wethTargetInEuler.gt(netWethReceived.add(loanCollat))){
       const wethToBuy = wethTargetInEuler.sub(netWethReceived).add(loanCollat)
-      const usdcAmount = await getUsdcAmountForWeth(wethToBuy, false, quoter, slippageTolerance)
-      const wethToTrade = wethToBuy
+      usdcAmount = await getUsdcAmountForWeth(wethToBuy, false, quoter, slippageTolerance)
+      wethToTrade = wethToBuy
     } else {
       const wethToSell = netWethReceived.add(loanCollat).sub(wethTargetInEuler)
-      const usdcAmount = await getUsdcAmountForWeth(wethToSell, true, quoter, slippageTolerance)
-      const wethToTrade = wethToSell
+      usdcAmount = await getUsdcAmountForWeth(wethToSell, true, quoter, slippageTolerance)
+      wethToTrade = wethToSell
     }
 
   }
 
   const wethLimitPrice = usdcAmount.wdiv(wethToTrade.abs()).mul(WETH_DECIMALS_DIFF)
+
   const usdcTargetInEuler = wethTargetInEuler.wmul(ethUsdPrice).div(2).div(WETH_DECIMALS_DIFF)
 
   const { delta: deltaNew, cr: crNew } = getDeltaAndCollat({

--- a/utils/calmBull.ts
+++ b/utils/calmBull.ts
@@ -70,7 +70,10 @@ export async function getAuctionOutcomes(params: getAuctionOutcomesType) {
   })
 
   const isIncreaseWeth = wethTargetInEuler.gt(loanCollat)
-  const isBorrowUsdc = usdcTargetInEuler.lt(loanDebt)
+  console.log('usdcTargetInEuler', usdcTargetInEuler.toString())
+  console.log('loanDebt', loanDebt.toString())
+
+  const isBorrowUsdc = usdcTargetInEuler.gt(loanDebt)
 
   return { isIncreaseWeth, isBorrowUsdc, isDepositingIntoCrab }
 }


### PR DESCRIPTION
Changed calculations for `getFullRebalanceDetails()` to match contract more closely.  

Was getting this error on a full rebalance deposit:
https://dashboard.tenderly.co/tx/goerli/0xe110fcbe0970cecc9bd1f2c6bbbbdb60ec17f55bdff7b76184ad47cbd79809ed/debugger?trace=0.12

Problem is that the _wethLimitPrice is for a buy where it should be for a sell. Changed the function to match the contract

Also fixed isBorrowUsdc output which gives the right value for the auction full rebalance tests on goerli 
fixes ENG-1101