### PR TITLE
Auction estimate based on ref vol 

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,9 +9,5 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - uses: borales/actions-yarn@v3.0.0
-        with:
-          cmd: install # will run `yarn install` command
-      - uses: borales/actions-yarn@v3.0.0
-        with:
-          cmd: test # will run `yarn test` command
+    - run: yarn install
+    - run: yarn test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,5 +9,5 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-    - run: yarn install
-    - run: yarn test
+      - run: yarn install
+      - run: yarn test

--- a/hooks/useAuctionEstimate.ts
+++ b/hooks/useAuctionEstimate.ts
@@ -8,6 +8,7 @@ import useCrabV2Store from '../store/crabV2Store'
 import usePriceStore from '../store/priceStore'
 import { AuctionStatus, AuctionType } from '../types'
 import { bnComparator } from '../utils'
+import useControllerStore from '../store/controllerStore'
 import { estimateAuction as estimateCrabAuction, getAuctionStatus } from '../utils/auction'
 import { getWsqueethFromCrabAmount } from '../utils/crab'
 import { calculateTotalDeposit } from '../utils/crabNetting'
@@ -16,8 +17,27 @@ import { useBullAuction } from './useBullAuction'
 import useQuoter from './useQuoter'
 
 export const useAuctionEstimate = () => {
+
   const auction = useCrabV2Store(s => s.auction)
-  const oSqthPrice = usePriceStore(s => s.oSqthPrice, bnComparator)
+  const { ethPriceBN } = usePriceStore(
+    s => ({ ethPriceBN: s.ethPrice }),
+    shallow,
+  )
+  const { osqthRefVol } = useCrabV2Store(s => ({ osqthRefVol: s.oSqthRefVolIndex }), shallow)
+  const { nfBN } = useControllerStore(s => ({ nfBN: s.normFactor }), shallow)
+
+  const ethPrice = convertBigNumber(auction.ethPrice || ethPriceBN, 18)
+  const nf = convertBigNumber(auction.normFactor || nfBN, 18)
+  const refVol = auction.osqthRefVol ?? osqthRefVol ;
+  const refPrice = ethPrice * nf * Math.exp((refVol/100)**2 * (17.5/365))/10000 *1e18
+  console.log('refVol is', refVol)
+  console.log('nf is', nf)
+  console.log('ethPrice is', ethPrice)
+  console.log('ref price is', refPrice )
+
+  // const oSqthPrice = usePriceStore(s => s.oSqthPrice, bnComparator)
+  const oSqthPrice = BigNumber.from(refPrice.toFixed()) // use ref price instead of pool price
+  console.log('oSQTH prcie is',oSqthPrice.toString())
   const vault = useCrabV2Store(s => s.vault, shallow)
   const usdcDeposits = useCrabNettingStore(s => s.depositQueued, bnComparator)
   const crabDeposits = useCrabNettingStore(s => s.withdrawQueued, bnComparator)

--- a/hooks/useAuctionEstimate.ts
+++ b/hooks/useAuctionEstimate.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, useMemo } from 'react'
 import shallow from 'zustand/shallow'
 import { BIG_ZERO } from '../constants/numbers'
 import { useCalmBullStore } from '../store/calmBullStore'
@@ -17,27 +17,23 @@ import { useBullAuction } from './useBullAuction'
 import useQuoter from './useQuoter'
 
 export const useAuctionEstimate = () => {
-
   const auction = useCrabV2Store(s => s.auction)
-  const { ethPriceBN } = usePriceStore(
-    s => ({ ethPriceBN: s.ethPrice }),
-    shallow,
-  )
+  const { ethPriceBN } = usePriceStore(s => ({ ethPriceBN: s.ethPrice }), shallow)
   const { osqthRefVol } = useCrabV2Store(s => ({ osqthRefVol: s.oSqthRefVolIndex }), shallow)
   const { nfBN } = useControllerStore(s => ({ nfBN: s.normFactor }), shallow)
 
   const ethPrice = convertBigNumber(auction.ethPrice || ethPriceBN, 18)
   const nf = convertBigNumber(auction.normFactor || nfBN, 18)
-  const refVol = auction.osqthRefVol ?? osqthRefVol ;
-  const refPrice = ethPrice * nf * Math.exp((refVol/100)**2 * (17.5/365))/10000 *1e18
+  const refVol = auction.osqthRefVol ?? osqthRefVol
+  const refPrice = ((ethPrice * nf * Math.exp((refVol / 100) ** 2 * (17.5 / 365))) / 10000) * 1e18
   console.log('refVol is', refVol)
   console.log('nf is', nf)
   console.log('ethPrice is', ethPrice)
-  console.log('ref price is', refPrice )
+  console.log('ref price is', refPrice)
 
   // const oSqthPrice = usePriceStore(s => s.oSqthPrice, bnComparator)
-  const oSqthPrice = BigNumber.from(refPrice.toFixed()) // use ref price instead of pool price
-  console.log('oSQTH prcie is',oSqthPrice.toString())
+  const oSqthPrice = useMemo(() => BigNumber.from(refPrice.toFixed()), [refPrice]) // use ref price instead of pool price
+  console.log('oSQTH price is', oSqthPrice.toString())
   const vault = useCrabV2Store(s => s.vault, shallow)
   const usdcDeposits = useCrabNettingStore(s => s.depositQueued, bnComparator)
   const crabDeposits = useCrabNettingStore(s => s.withdrawQueued, bnComparator)


### PR DESCRIPTION
The size estimate should now be based on ref vol instead of the squeeth pool price. This works but it seems to update `useAuctionEstimate` much more frequently than before. 

Any thoughts on how to fix appreciated!

Fixes ENG-1868