### PR TITLE
reduce cache expiry time to 3 days

### DIFF
--- a/container/CrabV2/Auction/Admin/AdminBidView.tsx
+++ b/container/CrabV2/Auction/Admin/AdminBidView.tsx
@@ -175,6 +175,13 @@ const AdminBidView: React.FC = () => {
       setFilteredBids(_filteredBids)
       const { clearingPrice: _clPrice } = getTxBidsAndClearingPrice(_filteredBids)
       setClearingPrice(_clPrice)
+
+      console.log('Approvals:', JSON.stringify(approvalMap, null, 2))
+      console.log('Balances:', JSON.stringify(balanceMap, null, 2))
+      console.log('Auction:', JSON.stringify(auction, null, 2))
+      console.log('Bids:', JSON.stringify(bids, null, 2))
+      console.log('Filtered Bids:', JSON.stringify(_filteredBids, null, 2))
+      console.log('Clearing Price:', _clPrice.toString())
     } catch (e) {
       console.log(e)
     }
@@ -347,17 +354,23 @@ const AdminBidView: React.FC = () => {
     crabAmount = auctionOsqthAmount.gt(sqthForCrab)
       ? crabAmount
       : getCrabFromSqueethAmount(auctionOsqthAmount.sub(1), vault!, supply)
-    
-    const adjustCrabAmount = (crabAmount: BigNumber, auctionOsqthAmount: BigNumber, vault: Vault, supply: BigNumber, x: number) => {
-      let count = 0;
+
+    const adjustCrabAmount = (
+      crabAmount: BigNumber,
+      auctionOsqthAmount: BigNumber,
+      vault: Vault,
+      supply: BigNumber,
+      x: number,
+    ) => {
+      let count = 0
       while (getWsqueethFromCrabAmount(crabAmount, vault!, supply).gt(auctionOsqthAmount) && count < x) {
-        crabAmount = crabAmount.sub(1); // decrease crabAmount by 1
-        count++;
+        crabAmount = crabAmount.sub(1) // decrease crabAmount by 1
+        count++
       }
-      return crabAmount;
+      return crabAmount
     }
-    const MAX_LOOP_TIMES = 10;
-    crabAmount = adjustCrabAmount(crabAmount, auctionOsqthAmount, vault!, supply, MAX_LOOP_TIMES);
+    const MAX_LOOP_TIMES = 10
+    crabAmount = adjustCrabAmount(crabAmount, auctionOsqthAmount, vault!, supply, MAX_LOOP_TIMES)
 
     console.log(
       'Crab',

--- a/utils/vpn.ts
+++ b/utils/vpn.ts
@@ -91,7 +91,7 @@ export async function isVPN(ipAddress: string): Promise<boolean> {
   return false
 }
 
-const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000
+const THREE_DAYS_IN_MS = 3 * 24 * 60 * 60 * 1000
 
 interface RedisResponse {
   value: string
@@ -111,8 +111,8 @@ export async function isIPBlockedInRedis(ip: string, currentTime: number) {
     try {
       const { value, timestamp } = redisData
 
-      // check if entry is valid and is less than 30 days old
-      if (value === BLOCKED_IP_VALUE && currentTime - timestamp <= THIRTY_DAYS_IN_MS) {
+      // check if entry is valid and is not more than 3 days old
+      if (value === BLOCKED_IP_VALUE && currentTime - timestamp <= THREE_DAYS_IN_MS) {
         isIPBlocked = true
       }
     } catch (error) {


### PR DESCRIPTION
# Task:

Reduce cache expiry time from 30 days to 3 days


## Description

Originally, the setting was for 30 days, indicating that when a data center is whitelisted, existing users would only gain access to the site after 30 days from their initial visit. However, a 3-day period seems to be an optimal balance, reducing the frequency of API calls while also avoiding issues with outdated data.

Fixes ENG-2043

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Testing code
- [ ] Document update or config files